### PR TITLE
Use isset() instead of checking the getAllIds() array

### DIFF
--- a/app/code/Radosav/Reportfix/Model/Magento/Reports/ResourceModel/Quote/Item/Collection.php
+++ b/app/code/Radosav/Reportfix/Model/Magento/Reports/ResourceModel/Quote/Item/Collection.php
@@ -14,9 +14,8 @@ class Collection extends \Magento\Reports\Model\ResourceModel\Quote\Item\Collect
         }
         $productData = $this->getProductData($productIds);
         $orderData = $this->getOrdersData($productIds);
-        $existing = $this->productResource->getAllIds();
         foreach ($items as $item) {
-            if(in_array($item->getProductId(),$existing)){
+            if(!isset($productData[$item->getProductId()])){
                 continue;
             }
             $item->setId($item->getProductId());
@@ -31,5 +30,3 @@ class Collection extends \Magento\Reports\Model\ResourceModel\Quote\Item\Collect
         return $this;
     }
 }
-	
-	


### PR DESCRIPTION
The getAllIds() array was still returning extra product ids in some cases, so I was still getting the error. This is my proposed solution, which works on my Magento 2.2.1 environmnt.